### PR TITLE
Fix issue with TwigEnvironment loader's not used when provided

### DIFF
--- a/src/TwigTransformer.php
+++ b/src/TwigTransformer.php
@@ -10,11 +10,13 @@ class TwigTransformer extends Transformer
 {
     protected $twig;
     protected $loaders = array();
+    protected $twigProvided = false;
 
     public function __construct(array $options = array())
     {
         $this->loaders['string'] = new \Twig_Loader_String();
         if (isset($options['twig'])) {
+            $this->twigProvided = true;
             $this->twig = $options['twig'];
         } else {
             $this->twig = new Twig_Environment($this->loaders['string'], $options);
@@ -36,6 +38,11 @@ class TwigTransformer extends Transformer
 
     public function renderFile($file, array $locals = array())
     {
+        if ($this->twigProvided) {
+            // If Twig_Environment was provided, we must suppose its loaders are initialized too.
+            return trim($this->twig->render($file, $locals));
+        }
+
         // Construct a new loader from the base path.
         $path = dirname(realpath($file));
         if (!isset($this->loaders[$path])) {

--- a/tests/TransformerTest.php
+++ b/tests/TransformerTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpTransformers\PhpTransformer\Test;
 
+use PhpTransformers\PhpTransformer\TwigTransformer;
+
 class TransformerTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -31,6 +33,21 @@ class TransformerTest extends \PHPUnit_Framework_TestCase
             'name' => 'Linus',
         );
         $actual = $engine->render($template, $locals);
+        $this->assertEquals('Hello, Linus!', $actual);
+    }
+
+    public function testTwigProvided()
+    {
+        $loader = new \Twig_Loader_Filesystem();
+        $loader->addPath(__DIR__.DIRECTORY_SEPARATOR.'Fixtures', 'test');
+        $twig = new \Twig_Environment($loader);
+        $engine = new TwigTransformer(array('twig' => $twig));
+
+        $template = '@test/TwigTransformer.twig';
+        $locals = array(
+            'name' => 'Linus',
+        );
+        $actual = $engine->renderFile($template, $locals);
         $this->assertEquals('Hello, Linus!', $actual);
     }
 


### PR DESCRIPTION
Fix an issue when TwigEnvironment is passed to the TwigTransformer. The loader initialized with the TwigEnvironment is not used.

This PR fix it by storing in the class the fact that the transformer was created with an already created TwigEnvironment and use this information to directly use TwigEnvironment loader instead of creating a new one.